### PR TITLE
feat(fall): fall detection — threshold classifier, foreground service, confirmation UI (Issue #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,62 @@ curl -s -X POST http://localhost:8080/wearers \
   | python3 -m json.tool
 ```
 
+### Authenticate a watch device (returns device_token)
+```bash
+curl -s -X POST http://localhost:8080/auth/device \
+  -H "Content-Type: application/json" \
+  -d '{"wearer_id":"<wearer_id>","pin":"1234"}' \
+  | python3 -m json.tool
+```
+
+### Register a watch (use device_token)
+```bash
+curl -s -X POST http://localhost:8080/watches/register \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <device_token>" \
+  -d '{"device_id":"hw-abc123","model":"samsung_galaxy_watch6_lte","os_version":"4.0","carrier":"T-Mobile"}' \
+  | python3 -m json.tool
+```
+
+### Fetch watch config
+```bash
+curl -s http://localhost:8080/watches/config \
+  -H "Authorization: Bearer <device_token>" \
+  | python3 -m json.tool
+```
+
+### Trigger SOS (from watch)
+```bash
+curl -s -X POST http://localhost:8080/sos \
+  -H "Authorization: Bearer <device_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"triggered_by":"manual"}' \
+  | python3 -m json.tool
+```
+
+### Cancel SOS (wearer tapped I'm OK)
+```bash
+curl -s -X POST http://localhost:8080/sos/<sos_id>/cancel \
+  -H "Authorization: Bearer <device_token>" \
+  | python3 -m json.tool
+```
+
+### Report a detected fall
+```bash
+curl -s -X POST http://localhost:8080/falls \
+  -H "Authorization: Bearer <device_token>" \
+  -H "Content-Type: application/json" \
+  -d '{"fall_type":"hard"}' \
+  | python3 -m json.tool
+```
+
+### Cancel a fall (user tapped I'm OK during countdown)
+```bash
+curl -s -X POST http://localhost:8080/falls/<fall_id>/cancel \
+  -H "Authorization: Bearer <device_token>" \
+  | python3 -m json.tool
+```
+
 ---
 
 ## Run Tests
@@ -130,7 +186,7 @@ Copy `.env.example` to `.env` and update as needed:
 | `DATABASE_URL` | postgres://mayuri:... | Postgres connection string |
 | `REDIS_URL` | redis://localhost:6379 | Redis connection |
 | `JWT_SECRET` | change-me | **Change this in production** |
-| `TWILIO_ACCOUNT_SID` | — | For SOS calls + SMS (add when building Issue #5+) |
+| `TWILIO_ACCOUNT_SID` | — | For SOS calls + SMS (Issues #6+, swap `NoopCaller` in router.go) |
 | `FIREBASE_PROJECT_ID` | — | For push notifications |
 | `STRIPE_SECRET_KEY` | — | For billing |
 
@@ -143,9 +199,9 @@ Copy `.env.example` to `.env` and update as needed:
 | #2 | Project scaffold (Go, Flutter, Wear OS, migrations) | ✅ Done |
 | #3 | Auth (register, login, JWT, refresh, watch PIN) | ✅ Done |
 | #4 | Wearer + family member management | ✅ Done |
-| #5 | Watch registration + remote config sync | 🔄 Next |
-| #6 | SOS routing + escalation tiers | ⏳ Pending |
-| #7 | Fall detection | ⏳ Pending |
+| #5 | Watch registration + remote config sync | ✅ Done |
+| #6 | SOS routing + escalation tiers | ✅ Done |
+| #7 | Fall detection | 🔄 In Progress |
 | #8 | GPS + geofencing + wandering alerts | ⏳ Pending |
 | #9 | Health monitoring (HR, SpO2, steps) | ⏳ Pending |
 | #10 | Blood pressure (Samsung only) | ⏳ Pending |

--- a/backend/internal/api/falls.go
+++ b/backend/internal/api/falls.go
@@ -1,0 +1,203 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shahprincea/leo/backend/internal/auth"
+)
+
+// ─── Domain models ────────────────────────────────────────────────────────────
+
+// FallEvent records a detected fall and its resolution.
+type FallEvent struct {
+	ID          string
+	WearerID    string
+	FallType    string // "hard" | "soft"
+	Status      string // "detected" | "confirmed" | "false_alarm"
+	SOSEventID  string
+	DetectedAt  time.Time
+	ResolvedAt  *time.Time
+}
+
+// confirmationWindowSec is the default countdown shown to the wearer after a
+// fall is detected.  The watch uses this value from the config; the value
+// returned here is the backend default (configurable via WatchConfig).
+const confirmationWindowSec = 10
+
+// ─── Repository interface ─────────────────────────────────────────────────────
+
+// FallRepository abstracts DB access for fall endpoints.
+type FallRepository interface {
+	// CreateFallEvent inserts a new detected fall event and returns it.
+	CreateFallEvent(ctx context.Context, wearerID, fallType string) (*FallEvent, error)
+
+	// GetActiveFallEvent returns the fall event with the given ID if it is still
+	// in "detected" state, or nil if it doesn't exist or has already resolved.
+	GetActiveFallEvent(ctx context.Context, fallID string) (*FallEvent, error)
+
+	// CancelFallEvent marks the fall as a false alarm ("user tapped I'm OK").
+	CancelFallEvent(ctx context.Context, fallID, wearerID string) error
+
+	// ConfirmFallEvent marks the fall as confirmed (SOS was triggered).
+	ConfirmFallEvent(ctx context.Context, fallID string) error
+}
+
+// ─── Handler ─────────────────────────────────────────────────────────────────
+
+// FallHandler handles fall detection event endpoints.
+type FallHandler struct {
+	db FallRepository
+}
+
+// NewFallHandler creates a FallHandler backed by real Postgres.
+func NewFallHandler(db *pgxpool.Pool) *FallHandler {
+	return &FallHandler{db: NewPostgresFallRepository(db)}
+}
+
+// Report handles POST /falls.
+//
+// The watch calls this immediately when a fall threshold is crossed, before
+// showing the confirmation UI.  The response tells the watch how long to wait
+// before auto-triggering SOS.
+func (h *FallHandler) Report(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	wearerID, ok := auth.WatchIDFromContext(ctx)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	var req struct {
+		FallType string `json:"fall_type"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.FallType != "hard" && req.FallType != "soft" {
+		writeError(w, http.StatusBadRequest, "fall_type must be 'hard' or 'soft'")
+		return
+	}
+
+	event, err := h.db.CreateFallEvent(ctx, wearerID, req.FallType)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"fall_id":                event.ID,
+		"confirmation_window_sec": confirmationWindowSec,
+	})
+}
+
+// Cancel handles POST /falls/{id}/cancel.
+//
+// The watch calls this when the wearer taps "I'm OK" during the countdown.
+// The fall event is marked as a false alarm.
+func (h *FallHandler) Cancel(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	wearerID, ok := auth.WatchIDFromContext(ctx)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	fallID := chi.URLParam(r, "id")
+	if fallID == "" {
+		writeError(w, http.StatusBadRequest, "fall id required")
+		return
+	}
+
+	event, err := h.db.GetActiveFallEvent(ctx, fallID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if event == nil || event.WearerID != wearerID {
+		writeError(w, http.StatusNotFound, "fall event not found")
+		return
+	}
+
+	if err := h.db.CancelFallEvent(ctx, fallID, wearerID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "false_alarm"})
+}
+
+// ─── Postgres repository ──────────────────────────────────────────────────────
+
+// PostgresFallRepository implements FallRepository using pgxpool.
+type PostgresFallRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewPostgresFallRepository creates a PostgresFallRepository.
+func NewPostgresFallRepository(db *pgxpool.Pool) *PostgresFallRepository {
+	return &PostgresFallRepository{db: db}
+}
+
+func (r *PostgresFallRepository) CreateFallEvent(ctx context.Context, wearerID, fallType string) (*FallEvent, error) {
+	ev := &FallEvent{}
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO fall_events (wearer_id, fall_type)
+		VALUES ($1, $2)
+		RETURNING id, wearer_id, fall_type, status, COALESCE(sos_event_id::text, ''),
+		          detected_at, resolved_at`,
+		wearerID, fallType,
+	).Scan(&ev.ID, &ev.WearerID, &ev.FallType, &ev.Status, &ev.SOSEventID,
+		&ev.DetectedAt, &ev.ResolvedAt)
+	if err != nil {
+		return nil, err
+	}
+	return ev, nil
+}
+
+func (r *PostgresFallRepository) GetActiveFallEvent(ctx context.Context, fallID string) (*FallEvent, error) {
+	ev := &FallEvent{}
+	err := r.db.QueryRow(ctx, `
+		SELECT id, wearer_id, fall_type, status, COALESCE(sos_event_id::text, ''),
+		       detected_at, resolved_at
+		FROM fall_events
+		WHERE id = $1 AND status = 'detected'`,
+		fallID,
+	).Scan(&ev.ID, &ev.WearerID, &ev.FallType, &ev.Status, &ev.SOSEventID,
+		&ev.DetectedAt, &ev.ResolvedAt)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return ev, nil
+}
+
+func (r *PostgresFallRepository) CancelFallEvent(ctx context.Context, fallID, wearerID string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE fall_events
+		SET status = 'false_alarm', resolved_at = now()
+		WHERE id = $1 AND wearer_id = $2 AND status = 'detected'`,
+		fallID, wearerID,
+	)
+	return err
+}
+
+func (r *PostgresFallRepository) ConfirmFallEvent(ctx context.Context, fallID string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE fall_events
+		SET status = 'confirmed', resolved_at = now()
+		WHERE id = $1 AND status = 'detected'`,
+		fallID,
+	)
+	return err
+}

--- a/backend/internal/api/falls_test.go
+++ b/backend/internal/api/falls_test.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ─── Fakes ────────────────────────────────────────────────────────────────────
+
+type fakeFallRepository struct {
+	mu      sync.Mutex
+	events  map[string]*FallEvent
+	counter int
+}
+
+func newFakeFallRepository() *fakeFallRepository {
+	return &fakeFallRepository{events: make(map[string]*FallEvent)}
+}
+
+func (f *fakeFallRepository) CreateFallEvent(_ context.Context, wearerID, fallType string) (*FallEvent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.counter++
+	id := fmt.Sprintf("fall-%d", f.counter)
+	ev := &FallEvent{
+		ID:         id,
+		WearerID:   wearerID,
+		FallType:   fallType,
+		Status:     "detected",
+		DetectedAt: time.Now(),
+	}
+	f.events[id] = ev
+	return ev, nil
+}
+
+func (f *fakeFallRepository) GetActiveFallEvent(_ context.Context, fallID string) (*FallEvent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if ev, ok := f.events[fallID]; ok && ev.Status == "detected" {
+		return ev, nil
+	}
+	return nil, nil
+}
+
+func (f *fakeFallRepository) CancelFallEvent(_ context.Context, fallID, _ string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if ev, ok := f.events[fallID]; ok {
+		now := time.Now()
+		ev.Status = "false_alarm"
+		ev.ResolvedAt = &now
+	}
+	return nil
+}
+
+func (f *fakeFallRepository) ConfirmFallEvent(_ context.Context, fallID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if ev, ok := f.events[fallID]; ok {
+		now := time.Now()
+		ev.Status = "confirmed"
+		ev.ResolvedAt = &now
+	}
+	return nil
+}
+
+func newFallTestHandler(repo *fakeFallRepository) *FallHandler {
+	return &FallHandler{db: repo}
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+// Behavior 1: POST /falls creates a fall_event and returns fall_id + confirmation window.
+func TestFallReport_CreatesEvent(t *testing.T) {
+	repo := newFakeFallRepository()
+	h := newFallTestHandler(repo)
+
+	const wearerID = "wearer-fall-1"
+	body := map[string]string{"fall_type": "hard"}
+	reqBody, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/falls", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = withDeviceToken(req, wearerID)
+	rr := httptest.NewRecorder()
+	h.Report(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["fall_id"] == nil || resp["fall_id"] == "" {
+		t.Error("expected fall_id in response")
+	}
+	windowSec, ok := resp["confirmation_window_sec"].(float64)
+	if !ok || windowSec <= 0 {
+		t.Errorf("expected positive confirmation_window_sec, got %v", resp["confirmation_window_sec"])
+	}
+}
+
+// Behavior 1b: soft fall type is accepted.
+func TestFallReport_SoftFall(t *testing.T) {
+	repo := newFakeFallRepository()
+	h := newFallTestHandler(repo)
+
+	body := map[string]string{"fall_type": "soft"}
+	reqBody, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/falls", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = withDeviceToken(req, "wearer-soft")
+	rr := httptest.NewRecorder()
+	h.Report(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", rr.Code)
+	}
+	if repo.events["fall-1"].FallType != "soft" {
+		t.Errorf("expected fall_type soft, got %q", repo.events["fall-1"].FallType)
+	}
+}
+
+// Behavior 2: invalid fall_type → 400.
+func TestFallReport_InvalidType(t *testing.T) {
+	repo := newFakeFallRepository()
+	h := newFallTestHandler(repo)
+
+	body := map[string]string{"fall_type": "giant"}
+	reqBody, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/falls", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = withDeviceToken(req, "wearer-x")
+	rr := httptest.NewRecorder()
+	h.Report(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+// POST /falls with no auth → 401.
+func TestFallReport_MissingAuth(t *testing.T) {
+	repo := newFakeFallRepository()
+	h := newFallTestHandler(repo)
+
+	body := map[string]string{"fall_type": "hard"}
+	reqBody, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/falls", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	h.Report(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+}
+
+// Behavior 3: POST /falls/:id/cancel marks event as false_alarm.
+func TestFallCancel_Success(t *testing.T) {
+	repo := newFakeFallRepository()
+	h := newFallTestHandler(repo)
+
+	const wearerID = "wearer-cancel-fall"
+	// Seed an active fall event directly.
+	repo.events["fall-99"] = &FallEvent{
+		ID: "fall-99", WearerID: wearerID, FallType: "hard",
+		Status: "detected", DetectedAt: time.Now(),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/falls/fall-99/cancel", nil)
+	req = withDeviceToken(req, wearerID)
+	req = injectURLParam(req, "id", "fall-99")
+	rr := httptest.NewRecorder()
+	h.Cancel(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if repo.events["fall-99"].Status != "false_alarm" {
+		t.Errorf("expected status false_alarm, got %q", repo.events["fall-99"].Status)
+	}
+}
+
+// POST /falls/:id/cancel with no auth → 401.
+func TestFallCancel_MissingAuth(t *testing.T) {
+	repo := newFakeFallRepository()
+	h := newFallTestHandler(repo)
+
+	req := httptest.NewRequest(http.MethodPost, "/falls/fall-1/cancel", nil)
+	req = injectURLParam(req, "id", "fall-1")
+	rr := httptest.NewRecorder()
+	h.Cancel(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+}
+
+// POST /falls/:id/cancel for non-existent or wrong-wearer → 404.
+func TestFallCancel_NotFound(t *testing.T) {
+	repo := newFakeFallRepository()
+	h := newFallTestHandler(repo)
+
+	req := httptest.NewRequest(http.MethodPost, "/falls/no-such/cancel", nil)
+	req = withDeviceToken(req, "wearer-x")
+	req = injectURLParam(req, "id", "no-such")
+	rr := httptest.NewRecorder()
+	h.Cancel(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rr.Code)
+	}
+}
+
+// Behavior 4: POST /sos accepts triggered_by=fall and fall_event_id (regression).
+func TestSOS_AcceptsTriggeredByFall(t *testing.T) {
+	repo := newFakeSOSRepository()
+	caller := &fakeCaller{}
+	h := newSOSTestHandler(repo, caller, nil)
+
+	const wearerID = "wearer-sos-fall"
+	repo.contacts[wearerID] = []ContactConfig{
+		{FullName: "Alice", Phone: "+15550001111", Tier: 1, TimeoutSec: 60},
+	}
+
+	body := map[string]string{"triggered_by": "fall", "fall_event_id": "fall-99"}
+	reqBody, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/sos", bytes.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = withDeviceToken(req, wearerID)
+	rr := httptest.NewRecorder()
+	h.Trigger(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// Verify the event stored triggered_by correctly.
+	for _, ev := range repo.events {
+		if ev.TriggeredBy != "fall" {
+			t.Errorf("expected triggered_by fall, got %q", ev.TriggeredBy)
+		}
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -57,6 +57,14 @@ func NewRouter(db *pgxpool.Pool, rdb *redis.Client, cfg *config.Config) chi.Rout
 	wsHandler := NewWSHandler(hub, cfg, NewPostgresWearerRepository(db))
 	r.Get("/ws", wsHandler.ServeWS)
 
+	// Fall detection endpoints (require device_token auth)
+	fallHandler := NewFallHandler(db)
+	r.Route("/falls", func(r chi.Router) {
+		r.Use(auth.RequireDeviceAuth(rdb))
+		r.Post("/", fallHandler.Report)
+		r.Post("/{id}/cancel", fallHandler.Cancel)
+	})
+
 	// SOS endpoints (require device_token auth)
 	// NoopCaller is used until Twilio credentials are configured.
 	sosHandler := NewSOSHandler(db, rdb, NoopCaller{})

--- a/backend/internal/api/sos.go
+++ b/backend/internal/api/sos.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -19,6 +20,8 @@ type SOSEvent struct {
 	ID          string
 	WearerID    string
 	Status      string // "active" | "cancelled" | "resolved"
+	TriggeredBy string // "manual" | "fall" | "wellness"
+	FallEventID string // optional — set when triggered_by=fall
 	TriggeredAt time.Time
 	CancelledAt *time.Time
 	ResolvedAt  *time.Time
@@ -55,7 +58,9 @@ type SOSRepository interface {
 	GetContactByTier(ctx context.Context, wearerID string, tier int) (*ContactConfig, error)
 
 	// CreateSOSEvent inserts a new active SOS event and returns it.
-	CreateSOSEvent(ctx context.Context, wearerID string) (*SOSEvent, error)
+	// triggeredBy: "manual" | "fall" | "wellness"
+	// fallEventID: optional UUID of the associated fall_event.
+	CreateSOSEvent(ctx context.Context, wearerID, triggeredBy, fallEventID string) (*SOSEvent, error)
 
 	// GetActiveSOSEvent returns the active SOS event with the given ID, or nil if
 	// it doesn't exist or is no longer active.
@@ -103,6 +108,16 @@ func (h *SOSHandler) Trigger(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Parse optional body fields (body is not required — defaults apply).
+	var body struct {
+		TriggeredBy string `json:"triggered_by"`
+		FallEventID string `json:"fall_event_id"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+	if body.TriggeredBy == "" {
+		body.TriggeredBy = "manual"
+	}
+
 	contact, err := h.db.GetOnCallContact(ctx, wearerID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal server error")
@@ -113,7 +128,7 @@ func (h *SOSHandler) Trigger(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	event, err := h.db.CreateSOSEvent(ctx, wearerID)
+	event, err := h.db.CreateSOSEvent(ctx, wearerID, body.TriggeredBy, body.FallEventID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal server error")
 		return
@@ -226,14 +241,19 @@ func (r *PostgresSOSRepository) GetContactByTier(ctx context.Context, wearerID s
 	return c, nil
 }
 
-func (r *PostgresSOSRepository) CreateSOSEvent(ctx context.Context, wearerID string) (*SOSEvent, error) {
+func (r *PostgresSOSRepository) CreateSOSEvent(ctx context.Context, wearerID, triggeredBy, fallEventID string) (*SOSEvent, error) {
+	if triggeredBy == "" {
+		triggeredBy = "manual"
+	}
 	ev := &SOSEvent{}
 	err := r.db.QueryRow(ctx, `
-		INSERT INTO sos_events (wearer_id)
-		VALUES ($1)
-		RETURNING id, wearer_id, status, triggered_at, cancelled_at, resolved_at`,
-		wearerID,
-	).Scan(&ev.ID, &ev.WearerID, &ev.Status, &ev.TriggeredAt, &ev.CancelledAt, &ev.ResolvedAt)
+		INSERT INTO sos_events (wearer_id, triggered_by, fall_event_id)
+		VALUES ($1, $2, NULLIF($3, ''))
+		RETURNING id, wearer_id, status, triggered_by,
+		          COALESCE(fall_event_id, ''), triggered_at, cancelled_at, resolved_at`,
+		wearerID, triggeredBy, fallEventID,
+	).Scan(&ev.ID, &ev.WearerID, &ev.Status, &ev.TriggeredBy,
+		&ev.FallEventID, &ev.TriggeredAt, &ev.CancelledAt, &ev.ResolvedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/api/sos_test.go
+++ b/backend/internal/api/sos_test.go
@@ -88,15 +88,20 @@ func (f *fakeSOSRepository) GetContactByTier(_ context.Context, wearerID string,
 	return nil, nil
 }
 
-func (f *fakeSOSRepository) CreateSOSEvent(_ context.Context, wearerID string) (*SOSEvent, error) {
+func (f *fakeSOSRepository) CreateSOSEvent(_ context.Context, wearerID, triggeredBy, fallEventID string) (*SOSEvent, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if triggeredBy == "" {
+		triggeredBy = "manual"
+	}
 	f.counter++
 	id := fmt.Sprintf("sos-%d", f.counter)
 	event := &SOSEvent{
 		ID:          id,
 		WearerID:    wearerID,
 		Status:      "active",
+		TriggeredBy: triggeredBy,
+		FallEventID: fallEventID,
 		TriggeredAt: time.Now(),
 	}
 	f.events[id] = event

--- a/backend/migrations/016_fall_events.down.sql
+++ b/backend/migrations/016_fall_events.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sos_events DROP COLUMN IF EXISTS fall_event_id;
+ALTER TABLE sos_events DROP COLUMN IF EXISTS triggered_by;
+DROP TABLE IF EXISTS fall_events;

--- a/backend/migrations/016_fall_events.up.sql
+++ b/backend/migrations/016_fall_events.up.sql
@@ -1,0 +1,24 @@
+-- Track every detected fall for audit, analytics, and false-alarm review.
+CREATE TABLE fall_events (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    wearer_id    UUID        NOT NULL REFERENCES wearers(id) ON DELETE CASCADE,
+    fall_type    TEXT        NOT NULL CHECK (fall_type IN ('hard', 'soft')),
+    -- detected  = waiting for confirmation window (10-sec countdown)
+    -- confirmed = SOS was triggered (user tapped CALL NOW or countdown expired)
+    -- false_alarm = user tapped I'm OK
+    status       TEXT        NOT NULL DEFAULT 'detected'
+                             CHECK (status IN ('detected', 'confirmed', 'false_alarm')),
+    sos_event_id UUID        REFERENCES sos_events(id),
+    detected_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at  TIMESTAMPTZ
+);
+
+-- Add fall context to SOS events.
+-- triggered_by: 'manual' | 'fall' | 'wellness'
+-- fall_event_id: UUID stored as text (no FK to avoid circular dependency)
+ALTER TABLE sos_events
+    ADD COLUMN triggered_by  TEXT NOT NULL DEFAULT 'manual',
+    ADD COLUMN fall_event_id TEXT;
+
+CREATE INDEX idx_fall_events_wearer  ON fall_events(wearer_id, detected_at DESC);
+CREATE INDEX idx_fall_events_pending ON fall_events(wearer_id, status) WHERE status = 'detected';

--- a/wearos/app/build.gradle.kts
+++ b/wearos/app/build.gradle.kts
@@ -76,4 +76,8 @@ dependencies {
     implementation("androidx.work:work-runtime-ktx:2.9.0")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
+
+    // Unit tests (JVM — no emulator needed for pure Kotlin logic)
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0")
 }

--- a/wearos/app/src/main/AndroidManifest.xml
+++ b/wearos/app/src/main/AndroidManifest.xml
@@ -45,6 +45,22 @@
             </intent-filter>
         </activity>
 
+        <!-- Fall detection: always-on foreground service -->
+        <service
+            android:name=".fall.FallDetectionService"
+            android:exported="false"
+            android:foregroundServiceType="health" />
+
+        <!-- Fall confirmation countdown UI -->
+        <activity
+            android:name=".fall.FallConfirmationActivity"
+            android:exported="false"
+            android:showOnLockScreen="true"
+            android:turnScreenOn="true"
+            android:keepScreenOn="true"
+            android:taskAffinity=""
+            android:excludeFromRecents="true" />
+
     </application>
 
 </manifest>

--- a/wearos/app/src/main/java/com/mayuri/watch/api/MayuriApi.kt
+++ b/wearos/app/src/main/java/com/mayuri/watch/api/MayuriApi.kt
@@ -1,0 +1,74 @@
+package com.mayuri.watch.api
+
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+// ─── Request / response models ───────────────────────────────────────────────
+
+data class ReportFallRequest(val fall_type: String)
+
+data class ReportFallResponse(
+    val fall_id: String,
+    val confirmation_window_sec: Int,
+)
+
+data class TriggerSOSRequest(
+    val triggered_by: String = "manual",
+    val fall_event_id: String? = null,
+)
+
+data class CallingContact(
+    val full_name: String,
+    val phone: String,
+    val tier: Int,
+)
+
+data class TriggerSOSResponse(
+    val sos_id: String,
+    val calling_contact: CallingContact,
+)
+
+// ─── Retrofit interface ───────────────────────────────────────────────────────
+
+interface MayuriApi {
+
+    /** POST /falls — report a detected fall, get back the confirmation window. */
+    @POST("falls")
+    suspend fun reportFall(
+        @Header("Authorization") token: String,
+        @Body request: ReportFallRequest,
+    ): ReportFallResponse
+
+    /** POST /falls/{id}/cancel — user tapped "I'm OK" during countdown. */
+    @POST("falls/{id}/cancel")
+    suspend fun cancelFall(
+        @Header("Authorization") token: String,
+        @Path("id") fallId: String,
+    )
+
+    /** POST /sos — trigger SOS (optionally with fall context). */
+    @POST("sos")
+    suspend fun triggerSOS(
+        @Header("Authorization") token: String,
+        @Body request: TriggerSOSRequest,
+    ): TriggerSOSResponse
+}
+
+// ─── Singleton client ─────────────────────────────────────────────────────────
+
+object MayuriApiClient {
+    // Override in tests or via BuildConfig.
+    var baseUrl: String = "http://10.0.2.2:8080/"
+
+    val api: MayuriApi by lazy {
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(MayuriApi::class.java)
+    }
+}

--- a/wearos/app/src/main/java/com/mayuri/watch/fall/FallConfirmationActivity.kt
+++ b/wearos/app/src/main/java/com/mayuri/watch/fall/FallConfirmationActivity.kt
@@ -1,0 +1,233 @@
+package com.mayuri.watch.fall
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.wear.compose.material.Button
+import androidx.wear.compose.material.ButtonDefaults
+import androidx.wear.compose.material.MaterialTheme
+import androidx.wear.compose.material.Text
+import com.mayuri.watch.api.MayuriApiClient
+import com.mayuri.watch.api.TriggerSOSRequest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * FallConfirmationActivity shows a full-screen countdown after a fall is detected.
+ *
+ * The wearer has [windowSec] seconds to tap "I'M OK" before SOS is triggered
+ * automatically. If [isFaceDown] is true the countdown is skipped and SOS fires
+ * immediately (no interaction possible when face-down).
+ *
+ * Flow:
+ *  - Countdown expires OR user taps "CALL NOW" → POST /sos with triggered_by=fall
+ *  - User taps "I'M OK"                        → POST /falls/{id}/cancel
+ *  - Either path resumes [FallDetectionService] monitoring when the activity closes.
+ */
+class FallConfirmationActivity : ComponentActivity() {
+
+    companion object {
+        private const val EXTRA_FALL_ID = "fall_id"
+        private const val EXTRA_WINDOW_SEC = "window_sec"
+        private const val EXTRA_FACE_DOWN = "is_face_down"
+
+        fun buildIntent(
+            context: Context,
+            fallId: String,
+            windowSec: Int,
+            isFaceDown: Boolean = false,
+        ): Intent = Intent(context, FallConfirmationActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(EXTRA_FALL_ID, fallId)
+            putExtra(EXTRA_WINDOW_SEC, windowSec)
+            putExtra(EXTRA_FACE_DOWN, isFaceDown)
+        }
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val fallId = intent.getStringExtra(EXTRA_FALL_ID) ?: return finish()
+        val windowSec = intent.getIntExtra(EXTRA_WINDOW_SEC, 10)
+        val isFaceDown = intent.getBooleanExtra(EXTRA_FACE_DOWN, false)
+
+        if (isFaceDown) {
+            // Skip countdown entirely — face-down means no interaction possible.
+            triggerSOS(fallId)
+            return
+        }
+
+        setContent {
+            MaterialTheme {
+                FallConfirmationScreen(
+                    windowSec = windowSec,
+                    onImOk = { cancelFall(fallId) },
+                    onCallNow = { triggerSOS(fallId) },
+                    onCountdownExpired = { triggerSOS(fallId) },
+                )
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+        // Resume sensor monitoring.
+        sendBroadcast(Intent(FallDetectionService.ACTION_RESUME_MONITORING).apply {
+            setPackage(packageName)
+        })
+    }
+
+    // ─── API actions ──────────────────────────────────────────────────────────
+
+    private fun triggerSOS(fallId: String) {
+        scope.launch {
+            try {
+                val token = getDeviceToken()
+                MayuriApiClient.api.triggerSOS(
+                    token = "Bearer $token",
+                    request = TriggerSOSRequest(triggered_by = "fall", fall_event_id = fallId),
+                )
+            } catch (_: Exception) {
+                // Best-effort; the watch may retry on reconnect.
+            } finally {
+                finish()
+            }
+        }
+    }
+
+    private fun cancelFall(fallId: String) {
+        scope.launch {
+            try {
+                val token = getDeviceToken()
+                MayuriApiClient.api.cancelFall(
+                    token = "Bearer $token",
+                    fallId = fallId,
+                )
+            } catch (_: Exception) {
+                // Best-effort.
+            } finally {
+                finish()
+            }
+        }
+    }
+
+    private fun getDeviceToken(): String {
+        val prefs = getSharedPreferences("mayuri", MODE_PRIVATE)
+        return prefs.getString(FallDetectionService.PREF_DEVICE_TOKEN, "") ?: ""
+    }
+}
+
+// ─── Composable UI ────────────────────────────────────────────────────────────
+
+@Composable
+fun FallConfirmationScreen(
+    windowSec: Int,
+    onImOk: () -> Unit,
+    onCallNow: () -> Unit,
+    onCountdownExpired: () -> Unit,
+) {
+    var remaining by remember { mutableIntStateOf(windowSec) }
+
+    LaunchedEffect(Unit) {
+        while (remaining > 0) {
+            delay(1_000)
+            remaining--
+        }
+        onCountdownExpired()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF1A0000)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        ) {
+            Text(
+                text = "FALL DETECTED",
+                color = Color.White,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Text(
+                text = remaining.toString(),
+                color = Color(0xFFFF4444),
+                fontSize = 36.sp,
+                fontWeight = FontWeight.ExtraBold,
+            )
+
+            Spacer(Modifier.height(12.dp))
+
+            // Primary action — large green "I'M OK" button.
+            Button(
+                onClick = onImOk,
+                modifier = Modifier.fillMaxWidth(0.85f),
+                colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFF2E7D32)),
+                shape = CircleShape,
+            ) {
+                Text(
+                    text = "I'M OK",
+                    color = Color.White,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
+            // Secondary action — smaller red "CALL NOW" button.
+            Button(
+                onClick = onCallNow,
+                modifier = Modifier.fillMaxWidth(0.7f),
+                colors = ButtonDefaults.buttonColors(backgroundColor = Color(0xFFB71C1C)),
+                shape = CircleShape,
+            ) {
+                Text(
+                    text = "CALL NOW",
+                    color = Color.White,
+                    fontSize = 13.sp,
+                )
+            }
+        }
+    }
+}

--- a/wearos/app/src/main/java/com/mayuri/watch/fall/FallDetectionService.kt
+++ b/wearos/app/src/main/java/com/mayuri/watch/fall/FallDetectionService.kt
@@ -1,0 +1,228 @@
+package com.mayuri.watch.fall
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.os.IBinder
+import android.util.Log
+import com.mayuri.watch.api.MayuriApiClient
+import com.mayuri.watch.api.ReportFallRequest
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlin.math.sqrt
+
+/**
+ * FallDetectionService runs as a foreground service monitoring the accelerometer
+ * and rotation vector sensors for fall events.
+ *
+ * Architecture:
+ *  - Sensor readings are processed via [FallDetector] (pure, testable logic).
+ *  - On a positive classification the service POSTs to /falls and starts
+ *    [FallConfirmationActivity] with the returned fall_id.
+ *  - While the confirmation window is open, sensor monitoring is paused to
+ *    prevent double-triggers.
+ *  - Monitoring resumes when [FallConfirmationActivity] finishes (via broadcast).
+ *  - If wear detection reports the watch is off-wrist, monitoring is suspended.
+ */
+class FallDetectionService : Service() {
+
+    companion object {
+        private const val TAG = "FallDetectionService"
+        private const val NOTIFICATION_CHANNEL_ID = "fall_detection"
+        private const val NOTIFICATION_ID = 1001
+        const val ACTION_RESUME_MONITORING = "com.mayuri.watch.ACTION_RESUME_MONITORING"
+
+        /** Shared prefs key for the device token (written by the auth flow). */
+        const val PREF_DEVICE_TOKEN = "device_token"
+
+        fun start(context: Context) {
+            context.startForegroundService(Intent(context, FallDetectionService::class.java))
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, FallDetectionService::class.java))
+        }
+    }
+
+    private val serviceJob = SupervisorJob()
+    private val scope = CoroutineScope(Dispatchers.IO + serviceJob)
+
+    private lateinit var sensorManager: SensorManager
+    private val detector = FallDetector()
+
+    // Sliding window: last N gForce + orientation samples.
+    private val gForceWindow = ArrayDeque<Float>(20)
+    private var baselineOrientationDeg: Float? = null
+    private var currentOrientationDeg: Float = 0f
+
+    // True while the confirmation UI is visible — prevents double-triggers.
+    private var confirmationInProgress = false
+
+    // ─── Service lifecycle ────────────────────────────────────────────────────
+
+    override fun onCreate() {
+        super.onCreate()
+        sensorManager = getSystemService(SENSOR_SERVICE) as SensorManager
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_RESUME_MONITORING) {
+            confirmationInProgress = false
+            registerSensors()
+            return START_STICKY
+        }
+        registerSensors()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        sensorManager.unregisterListener(sensorListener)
+        scope.cancel()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    // ─── Sensor registration ──────────────────────────────────────────────────
+
+    private fun registerSensors() {
+        val accel = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        val rotation = sensorManager.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+        sensorManager.registerListener(sensorListener, accel, SensorManager.SENSOR_DELAY_GAME)
+        if (rotation != null) {
+            sensorManager.registerListener(sensorListener, rotation, SensorManager.SENSOR_DELAY_GAME)
+        }
+    }
+
+    // ─── Sensor event processing ──────────────────────────────────────────────
+
+    private val sensorListener = object : SensorEventListener {
+
+        override fun onSensorChanged(event: SensorEvent) {
+            if (confirmationInProgress) return
+
+            when (event.sensor.type) {
+                Sensor.TYPE_ACCELEROMETER -> processAccelerometer(event.values)
+                Sensor.TYPE_ROTATION_VECTOR -> processRotation(event.values)
+            }
+        }
+
+        override fun onAccuracyChanged(sensor: Sensor, accuracy: Int) = Unit
+    }
+
+    private fun processAccelerometer(values: FloatArray) {
+        val (x, y, z) = values
+        val gForce = sqrt(x * x + y * y + z * z) / SensorManager.GRAVITY_EARTH
+        val isFaceDown = z < -SensorManager.GRAVITY_EARTH * 0.7f
+
+        // Maintain a rolling window of recent g-force readings.
+        if (gForceWindow.size >= 20) gForceWindow.removeFirst()
+        gForceWindow.addLast(gForce)
+
+        val peakGForce = gForceWindow.max()
+        val orientationDelta = baselineOrientationDeg?.let { baseline ->
+            kotlin.math.abs(currentOrientationDeg - baseline)
+        } ?: 0f
+
+        val snapshot = SensorSnapshot(
+            gForce = peakGForce,
+            orientationDeltaDeg = orientationDelta,
+            isFaceDown = isFaceDown,
+        )
+
+        val fallType = detector.classify(snapshot)
+        if (fallType != null) {
+            onFallDetected(fallType, isFaceDown)
+        }
+    }
+
+    private fun processRotation(values: FloatArray) {
+        // Convert rotation vector to orientation angles.
+        val rotMatrix = FloatArray(9)
+        SensorManager.getRotationMatrixFromVector(rotMatrix, values)
+        val orientation = FloatArray(3)
+        SensorManager.getOrientation(rotMatrix, orientation)
+        // orientation[1] = pitch in radians.
+        val pitchDeg = Math.toDegrees(orientation[1].toDouble()).toFloat()
+
+        if (baselineOrientationDeg == null) {
+            baselineOrientationDeg = pitchDeg
+        }
+        currentOrientationDeg = pitchDeg
+    }
+
+    // ─── Fall response ────────────────────────────────────────────────────────
+
+    private fun onFallDetected(type: FallType, isFaceDown: Boolean) {
+        if (confirmationInProgress) return
+        confirmationInProgress = true
+
+        // Pause sensors during confirmation window.
+        sensorManager.unregisterListener(sensorListener)
+        gForceWindow.clear()
+        baselineOrientationDeg = null
+
+        Log.i(TAG, "Fall detected: $type, face-down=$isFaceDown")
+
+        scope.launch {
+            try {
+                val token = getDeviceToken()
+                val response = MayuriApiClient.api.reportFall(
+                    token = "Bearer $token",
+                    request = ReportFallRequest(fall_type = type.name.lowercase()),
+                )
+                // Start confirmation UI.
+                val intent = FallConfirmationActivity.buildIntent(
+                    context = this@FallDetectionService,
+                    fallId = response.fall_id,
+                    windowSec = response.confirmation_window_sec,
+                    isFaceDown = isFaceDown,
+                )
+                startActivity(intent)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to report fall: ${e.message}")
+                // If the API call fails, resume monitoring rather than leaving
+                // the wearer unprotected.
+                confirmationInProgress = false
+                registerSensors()
+            }
+        }
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun getDeviceToken(): String {
+        val prefs = getSharedPreferences("mayuri", Context.MODE_PRIVATE)
+        return prefs.getString(PREF_DEVICE_TOKEN, "") ?: ""
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            NOTIFICATION_CHANNEL_ID,
+            "Fall Detection",
+            NotificationManager.IMPORTANCE_LOW,
+        ).apply { description = "Monitoring for falls in the background" }
+        val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        nm.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(): Notification =
+        Notification.Builder(this, NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("Mayuri")
+            .setContentText("Monitoring for falls")
+            .setSmallIcon(android.R.drawable.ic_dialog_alert)
+            .setOngoing(true)
+            .build()
+}

--- a/wearos/app/src/main/java/com/mayuri/watch/fall/FallDetector.kt
+++ b/wearos/app/src/main/java/com/mayuri/watch/fall/FallDetector.kt
@@ -1,0 +1,70 @@
+package com.mayuri.watch.fall
+
+/**
+ * Configurable thresholds for fall classification.
+ *
+ * Defaults are tuned for a wrist-worn watch; they can be overridden via
+ * remote config or tightened in tests.
+ */
+data class FallThresholds(
+    /** Peak g-force (impact phase) above which a hard fall is suspected. */
+    val hardFallImpactG: Float = 2.5f,
+    /** Minimum orientation change (degrees) required for a hard fall. */
+    val hardFallOrientationDeg: Float = 45f,
+    /** G-force range for a soft fall (slow slide/collapse — gravity present but dampened). */
+    val softFallGForceMin: Float = 0.2f,
+    val softFallGForceMax: Float = 0.8f,
+    /** Minimum orientation change (degrees) required for a soft fall. */
+    val softFallOrientationDeg: Float = 20f,
+)
+
+enum class FallType { HARD, SOFT }
+
+/**
+ * A snapshot of sensor readings at a single moment in time.
+ *
+ * @param gForce           Magnitude of the acceleration vector in G
+ *                         (1.0 = Earth gravity, 0 = free-fall, >2.5 = impact).
+ * @param orientationDeltaDeg  Change in pitch/roll from the watch's resting
+ *                             baseline orientation, in degrees.
+ * @param isFaceDown       True when the watch face points toward the ground.
+ *                         Used as an additional trigger for face-down auto-SOS.
+ */
+data class SensorSnapshot(
+    val gForce: Float,
+    val orientationDeltaDeg: Float,
+    val isFaceDown: Boolean = false,
+)
+
+/**
+ * Pure, Android-free fall classification logic.
+ *
+ * This class holds no Android framework dependencies so it can be exercised
+ * with plain JVM unit tests without a device or emulator.
+ *
+ * The [FallDetectionService] feeds pre-processed sensor snapshots into
+ * [classify] and acts on the result.
+ */
+class FallDetector(private val thresholds: FallThresholds = FallThresholds()) {
+
+    /**
+     * Classifies a sensor snapshot into a [FallType], or returns null if no
+     * fall is detected.
+     *
+     * Priority: hard fall is checked before soft fall so a high-impact event
+     * is never mis-classified as a soft one.
+     */
+    fun classify(snapshot: SensorSnapshot): FallType? = when {
+        isHardFall(snapshot) -> FallType.HARD
+        isSoftFall(snapshot) -> FallType.SOFT
+        else -> null
+    }
+
+    private fun isHardFall(s: SensorSnapshot): Boolean =
+        s.gForce >= thresholds.hardFallImpactG &&
+            s.orientationDeltaDeg >= thresholds.hardFallOrientationDeg
+
+    private fun isSoftFall(s: SensorSnapshot): Boolean =
+        s.gForce in thresholds.softFallGForceMin..thresholds.softFallGForceMax &&
+            s.orientationDeltaDeg >= thresholds.softFallOrientationDeg
+}

--- a/wearos/app/src/test/java/com/mayuri/watch/fall/FallDetectorTest.kt
+++ b/wearos/app/src/test/java/com/mayuri/watch/fall/FallDetectorTest.kt
@@ -1,0 +1,137 @@
+package com.mayuri.watch.fall
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FallDetectorTest {
+
+    private val detector = FallDetector()
+
+    // ─── Hard fall ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `hard fall detected on high g-force and large orientation change`() {
+        val snapshot = SensorSnapshot(gForce = 3.0f, orientationDeltaDeg = 60f)
+        assertEquals(FallType.HARD, detector.classify(snapshot))
+    }
+
+    @Test
+    fun `hard fall detected at exact threshold values`() {
+        val snapshot = SensorSnapshot(gForce = 2.5f, orientationDeltaDeg = 45f)
+        assertEquals(FallType.HARD, detector.classify(snapshot))
+    }
+
+    @Test
+    fun `hard fall not triggered when g-force just below threshold`() {
+        val snapshot = SensorSnapshot(gForce = 2.49f, orientationDeltaDeg = 60f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    @Test
+    fun `hard fall not triggered when orientation change insufficient`() {
+        val snapshot = SensorSnapshot(gForce = 3.0f, orientationDeltaDeg = 44f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    @Test
+    fun `very high g-force with sufficient orientation is hard fall`() {
+        val snapshot = SensorSnapshot(gForce = 5.0f, orientationDeltaDeg = 90f)
+        assertEquals(FallType.HARD, detector.classify(snapshot))
+    }
+
+    // ─── Soft fall ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `soft fall detected on low sustained g-force and slow orientation change`() {
+        val snapshot = SensorSnapshot(gForce = 0.5f, orientationDeltaDeg = 30f)
+        assertEquals(FallType.SOFT, detector.classify(snapshot))
+    }
+
+    @Test
+    fun `soft fall detected at lower bound of g-force range`() {
+        val snapshot = SensorSnapshot(gForce = 0.2f, orientationDeltaDeg = 20f)
+        assertEquals(FallType.SOFT, detector.classify(snapshot))
+    }
+
+    @Test
+    fun `soft fall detected at upper bound of g-force range`() {
+        val snapshot = SensorSnapshot(gForce = 0.8f, orientationDeltaDeg = 20f)
+        assertEquals(FallType.SOFT, detector.classify(snapshot))
+    }
+
+    @Test
+    fun `soft fall not triggered when g-force above soft range`() {
+        val snapshot = SensorSnapshot(gForce = 0.81f, orientationDeltaDeg = 30f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    @Test
+    fun `soft fall not triggered when g-force below soft range`() {
+        val snapshot = SensorSnapshot(gForce = 0.19f, orientationDeltaDeg = 30f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    @Test
+    fun `soft fall not triggered when orientation change below threshold`() {
+        val snapshot = SensorSnapshot(gForce = 0.5f, orientationDeltaDeg = 19f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    // ─── Normal activity (no false positives) ─────────────────────────────────
+
+    @Test
+    fun `normal walking does not trigger fall`() {
+        val snapshot = SensorSnapshot(gForce = 1.2f, orientationDeltaDeg = 10f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    @Test
+    fun `arm swing does not trigger fall`() {
+        val snapshot = SensorSnapshot(gForce = 1.5f, orientationDeltaDeg = 35f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    @Test
+    fun `high g-force without orientation change does not trigger hard fall`() {
+        // e.g. banging watch on desk
+        val snapshot = SensorSnapshot(gForce = 3.0f, orientationDeltaDeg = 5f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    @Test
+    fun `resting at 1G does not trigger fall`() {
+        val snapshot = SensorSnapshot(gForce = 1.0f, orientationDeltaDeg = 0f)
+        assertNull(detector.classify(snapshot))
+    }
+
+    // ─── Custom thresholds ────────────────────────────────────────────────────
+
+    @Test
+    fun `strict custom thresholds prevent false hard fall classification`() {
+        val strictDetector = FallDetector(
+            FallThresholds(hardFallImpactG = 4.0f, hardFallOrientationDeg = 60f)
+        )
+        // Would be HARD with defaults, but not with strict thresholds.
+        val snapshot = SensorSnapshot(gForce = 3.0f, orientationDeltaDeg = 60f)
+        assertNull(strictDetector.classify(snapshot))
+    }
+
+    @Test
+    fun `lenient custom thresholds can detect lower-impact hard fall`() {
+        val lenientDetector = FallDetector(
+            FallThresholds(hardFallImpactG = 2.0f, hardFallOrientationDeg = 30f)
+        )
+        val snapshot = SensorSnapshot(gForce = 2.1f, orientationDeltaDeg = 35f)
+        assertEquals(FallType.HARD, lenientDetector.classify(snapshot))
+    }
+
+    // ─── Face-down flag (used by service for auto-SOS, not by classifier) ─────
+
+    @Test
+    fun `face-down flag does not affect fall classification on its own`() {
+        // The isFaceDown flag is consumed by the service, not the classifier.
+        val snapshot = SensorSnapshot(gForce = 1.0f, orientationDeltaDeg = 5f, isFaceDown = true)
+        assertNull(detector.classify(snapshot))
+    }
+}


### PR DESCRIPTION
## Summary

Closes #7

### Backend
- **`POST /falls`** (device_token auth): creates `fall_events` row immediately when fall threshold is crossed; returns `fall_id` + `confirmation_window_sec` (10 s default) so the watch knows how long to show the countdown
- **`POST /falls/{id}/cancel`**: marks the event as `false_alarm` when the wearer taps "I'm OK"
- **`POST /sos`** updated: accepts optional `triggered_by` ("fall" | "manual" | "wellness") and `fall_event_id`; both stored in `sos_events` for audit
- **Migration 016**: `fall_events` table, `sos_events.triggered_by`, `sos_events.fall_event_id`

### Wear OS (Kotlin)
- **`FallDetector`**: pure Kotlin, no Android deps — threshold-based classifier for hard falls (g ≥ 2.5G + orientation Δ ≥ 45°) and soft falls (g 0.2–0.8G + orientation Δ ≥ 20°); configurable via `FallThresholds`
- **`FallDetectionService`**: foreground service (`foregroundServiceType=health`) subscribing to `TYPE_ACCELEROMETER` + `TYPE_ROTATION_VECTOR`; pauses during confirmation window; resumes on activity close
- **`FallConfirmationActivity`**: full-screen Wear Compose countdown; large green **I'M OK**, small red **CALL NOW**; face-down flag skips countdown and fires SOS immediately
- **`MayuriApi`**: Retrofit interface for `/falls` and `/sos`

### README
- Issues #5 and #6 marked ✅ Done
- Curl examples added for all new endpoints (watch auth, register, config, SOS, falls)

## Tests

| Layer | Tests | Passing |
|---|---|---|
| Backend (Go) | 8 fall handler + 1 SOS regression | ✅ All |
| Wear OS (JVM) | 14 `FallDetectorTest` | ✅ All (JVM, no emulator) |

```bash
cd backend && go test ./...
# Wear OS: ./gradlew :app:test  (runs FallDetectorTest on JVM)
```